### PR TITLE
feat: add transcript tool for clean conversation export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -201,6 +201,53 @@ class ClaudeHistorianServer {
         }
       },
     );
+
+    this.server.registerTool(
+      'transcript',
+      {
+        title: 'Get Session Transcript',
+        description:
+          'Get a clean conversation transcript for a session — only human/assistant text, no tool calls or system content. Ideal for providing accurate conversation context to sub-agents.',
+        inputSchema: {
+          session_id: z
+            .string()
+            .optional()
+            .default('latest')
+            .describe(
+              'Session ID, short prefix, or "latest" (default). Tip: pass process.env.CLAUDE_SESSION_ID when available.',
+            ),
+          format: z
+            .enum(['text', 'json'])
+            .optional()
+            .default('text')
+            .describe('Output format: "text" for readable transcript, "json" for structured data'),
+          max_messages: z
+            .number()
+            .optional()
+            .describe('Maximum number of messages to return (returns all if omitted)'),
+        },
+        annotations: {
+          readOnlyHint: true,
+          idempotentHint: true,
+        },
+      },
+      async (args) => {
+        try {
+          return await this.handleTranscript(args as Record<string, unknown>);
+        } catch (error) {
+          console.error('Tool execution error:', error);
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Error executing transcript: ${error instanceof Error ? error.message : String(error)}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      },
+    );
   }
 
   private async handleSearch(
@@ -463,6 +510,49 @@ class ClaudeHistorianServer {
     const text = this.formatter.formatCompactSummary([result.results], sessionId);
 
     return { content: [{ type: 'text', text }] };
+  }
+
+  private async handleTranscript(
+    args: Record<string, unknown>,
+  ): Promise<{ content: { type: 'text'; text: string }[] }> {
+    const sessionId = (args.session_id as string) || 'latest';
+    const format = (args.format as string) || 'text';
+    const maxMessages = args.max_messages as number | undefined;
+
+    const result = await this.universalEngine.getSessionTranscript(sessionId);
+
+    if (result.message_count === 0) {
+      const hint =
+        sessionId === 'latest'
+          ? 'No sessions found.'
+          : sessionId.length < 36
+            ? `No session matching prefix "${sessionId}".`
+            : `No session found with ID "${sessionId}".`;
+      return { content: [{ type: 'text', text: JSON.stringify({ error: hint }) }] };
+    }
+
+    const messages = maxMessages ? result.messages.slice(0, maxMessages) : result.messages;
+
+    if (format === 'json') {
+      const output = { ...result, messages };
+      return { content: [{ type: 'text', text: JSON.stringify(output, null, 2) }] };
+    }
+
+    // Text format: readable transcript
+    const lines: string[] = [
+      `📜 Transcript: ${result.session_id} (${messages.length} messages)`,
+      `Project: ${result.project_path || 'unknown'}`,
+      '',
+    ];
+
+    for (const msg of messages) {
+      const role = msg.role === 'user' ? '👤 User' : '🤖 Assistant';
+      lines.push(`--- ${role} [${msg.timestamp}] ---`);
+      lines.push(msg.text);
+      lines.push('');
+    }
+
+    return { content: [{ type: 'text', text: lines.join('\n') }] };
   }
 
   async run(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -224,7 +224,15 @@ class ClaudeHistorianServer {
           max_messages: z
             .number()
             .optional()
-            .describe('Maximum number of messages to return (returns all if omitted)'),
+            .describe(
+              'Maximum number of messages from the start of the conversation (returns all if omitted)',
+            ),
+          latest: z
+            .number()
+            .optional()
+            .describe(
+              'Return only the N most recent messages. Takes priority over max_messages. E.g. latest=50 returns the last 50 messages.',
+            ),
         },
         annotations: {
           readOnlyHint: true,
@@ -518,6 +526,7 @@ class ClaudeHistorianServer {
     const sessionId = (args.session_id as string) || 'latest';
     const format = (args.format as string) || 'text';
     const maxMessages = args.max_messages as number | undefined;
+    const latest = args.latest as number | undefined;
 
     const result = await this.universalEngine.getSessionTranscript(sessionId);
 
@@ -531,7 +540,13 @@ class ClaudeHistorianServer {
       return { content: [{ type: 'text', text: JSON.stringify({ error: hint }) }] };
     }
 
-    const messages = maxMessages ? result.messages.slice(0, maxMessages) : result.messages;
+    // latest takes priority: slice from end. max_messages slices from start.
+    let messages = result.messages;
+    if (latest) {
+      messages = messages.slice(-latest);
+    } else if (maxMessages) {
+      messages = messages.slice(0, maxMessages);
+    }
 
     if (format === 'json') {
       const output = { ...result, messages };

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,6 +156,25 @@ export interface ToolPattern {
   intelligentInsights?: string[];
 }
 
+// ── Transcript types ──────────────────────────────────────────────
+
+/** A single entry in a conversation transcript (text only, no tool calls). */
+export interface TranscriptEntry {
+  role: 'user' | 'assistant';
+  text: string;
+  timestamp: string;
+}
+
+/** Full transcript result for a session. */
+export interface TranscriptResult {
+  session_id: string;
+  project_path: string | null;
+  message_count: number;
+  start_time: string | null;
+  end_time: string | null;
+  messages: TranscriptEntry[];
+}
+
 // ── Session / plan types ───────────────────────────────────────────
 
 /** Minimal session metadata tracked during JSONL parsing. */

--- a/src/universal-engine.ts
+++ b/src/universal-engine.ts
@@ -8,17 +8,25 @@
  * file for potential future reuse.
  */
 import { HistorySearchEngine } from './search.js';
+import { createReadStream } from 'fs';
+import { createInterface } from 'readline';
+import { readFile, stat } from 'fs/promises';
+import { join } from 'path';
+
 import {
   SearchResult,
   FileContext,
   ErrorSolution,
   CompactMessage,
+  ClaudeMessage,
   PlanResult,
   SessionInfo,
   ToolPattern,
   CompactSummaryData,
+  TranscriptEntry,
+  TranscriptResult,
 } from './types.js';
-import { findProjectDirectories } from './utils.js';
+import { findProjectDirectories, getClaudeProjectsPath } from './utils.js';
 
 /* DEAD: Desktop imports — claudeDesktopAvailable hardcoded false (issue #70)
 import {
@@ -373,6 +381,150 @@ export class UniversalHistorySearchEngine {
       source: 'claude-code',
       results: plans,
       enhanced: false,
+    };
+  }
+
+  // ── Transcript extraction ──────────────────────────────────────────
+
+  /**
+   * Extract a clean conversation transcript for a specific session.
+   *
+   * Returns only user and assistant text messages — no tool_use, tool_result,
+   * thinking blocks, or system content. Designed for providing accurate
+   * conversation context to sub-agents.
+   *
+   * @param sessionId - Session UUID, short prefix, or "latest".
+   * @returns Clean transcript with role, text, and timestamp per message.
+   */
+  async getSessionTranscript(sessionId: string): Promise<TranscriptResult> {
+    await this.initialize();
+
+    const emptyResult: TranscriptResult = {
+      session_id: sessionId,
+      project_path: null,
+      message_count: 0,
+      start_time: null,
+      end_time: null,
+      messages: [],
+    };
+
+    // Resolve "latest" keyword
+    let resolvedSessionId = sessionId;
+    if (sessionId.toLowerCase() === 'latest') {
+      const recent = await this.claudeCodeEngine.getRecentSessions(1);
+      if (recent.length > 0) {
+        resolvedSessionId = recent[0].session_id;
+      } else {
+        return emptyResult;
+      }
+    }
+
+    // Find the session JSONL file across all project directories
+    const projectDirs = await findProjectDirectories();
+    let foundFilePath: string | null = null;
+    let foundProjectDir = '';
+
+    for (const projectDir of projectDirs) {
+      const projectsPath = getClaudeProjectsPath();
+
+      // Try exact match first
+      const exactPath = join(projectsPath, projectDir, `${resolvedSessionId}.jsonl`);
+      try {
+        await stat(exactPath);
+        foundFilePath = exactPath;
+        foundProjectDir = projectDir;
+        break;
+      } catch {
+        // Not found, try prefix match
+      }
+
+      // Prefix search
+      try {
+        const { readdir } = await import('fs/promises');
+        const files = await readdir(join(projectsPath, projectDir));
+        const match = files.find((f) => f.startsWith(resolvedSessionId) && f.endsWith('.jsonl'));
+        if (match) {
+          foundFilePath = join(projectsPath, projectDir, match);
+          foundProjectDir = projectDir;
+          break;
+        }
+      } catch {
+        // Directory not readable, continue
+      }
+    }
+
+    if (!foundFilePath) {
+      return { ...emptyResult, session_id: resolvedSessionId };
+    }
+
+    // Parse the JSONL file, extracting only user/assistant text content
+    const transcript: TranscriptEntry[] = [];
+    const SMALL_FILE_THRESHOLD = 400_000;
+
+    const processLine = (line: string): void => {
+      if (!line.trim()) return;
+      try {
+        const msg = JSON.parse(line) as ClaudeMessage;
+
+        // Only include user and assistant messages
+        if (msg.type !== 'user' && msg.type !== 'assistant') return;
+        if (!msg.message?.content) return;
+
+        // Extract only text content (no tool_use, tool_result, thinking)
+        let text = '';
+        if (typeof msg.message.content === 'string') {
+          text = msg.message.content;
+        } else if (Array.isArray(msg.message.content)) {
+          text = (msg.message.content as Array<{ type: string; text?: string }>)
+            .filter((block) => block.type === 'text')
+            .map((block) => block.text ?? '')
+            .join('\n')
+            .trim();
+        }
+
+        // Skip empty messages (e.g. assistant messages that were only tool calls)
+        if (!text) return;
+
+        // Skip system-reminder content injected into user messages
+        if (msg.type === 'user' && text.startsWith('<tool_result')) return;
+
+        transcript.push({
+          role: msg.type,
+          text,
+          timestamp: msg.timestamp,
+        });
+      } catch {
+        // Skip malformed lines
+      }
+    };
+
+    try {
+      const fileStats = await stat(foundFilePath);
+      if (fileStats.size < SMALL_FILE_THRESHOLD) {
+        const content = await readFile(foundFilePath, 'utf-8');
+        for (const line of content.split('\n')) {
+          processLine(line);
+        }
+      } else {
+        const fileStream = createReadStream(foundFilePath, { encoding: 'utf8' });
+        const rl = createInterface({ input: fileStream, crlfDelay: Infinity });
+        for await (const line of rl) {
+          processLine(line);
+        }
+      }
+    } catch {
+      return { ...emptyResult, session_id: resolvedSessionId };
+    }
+
+    const decodedPath = foundProjectDir.replace(/-/g, '/');
+
+    return {
+      session_id: resolvedSessionId,
+      project_path: decodedPath,
+      message_count: transcript.length,
+      start_time: transcript[0]?.timestamp ?? null,
+      end_time: transcript[transcript.length - 1]?.timestamp ?? null,
+      messages: transcript,
     };
   }
 


### PR DESCRIPTION
## Summary

- Adds a new `transcript` tool that returns only human/assistant text messages from a session — no tool_use, tool_result, thinking blocks, or system content
- Supports `session_id` (full UUID, short prefix, or `"latest"`), `text`/`json` output formats, and optional `max_messages` limit
- Designed for providing accurate conversation context to sub-agents without tool interaction noise

## Motivation

Sub-agents spawned by Claude Code start with zero conversation context. Existing tools (`search`, `inspect`) are great for searching history and getting structured summaries, but there's no way to get the raw human/assistant conversation text for a specific session. This is needed when you want to give a sub-agent an accurate, unedited view of what was discussed — not a search result or AI-generated summary.

## Implementation

- **`src/types.ts`**: Added `TranscriptEntry` and `TranscriptResult` types
- **`src/universal-engine.ts`**: Added `getSessionTranscript()` method that reads JSONL directly, filtering to only `user`/`assistant` messages and extracting only `type: "text"` content blocks
- **`src/index.ts`**: Registered the `transcript` tool with session_id, format, and max_messages parameters

Reuses existing infrastructure (session resolution with prefix/latest support, project directory scanning) — no new dependencies.

## Example output

```
📜 Transcript: 30c3e917 (65 messages)
Project: /Users/neil

--- 👤 User [2026-04-06T01:23:45.000Z] ---
search to see if there is an mcp that allows conversation export...

--- 🤖 Assistant [2026-04-06T01:24:12.000Z] ---
Good news — several MCPs exist for this exact purpose...
```

## Test plan

- [x] Build passes (`npm run build`)
- [x] Lint passes (pre-commit hooks)
- [x] Tested `transcript` with `session_id: "latest"` — returns clean text
- [x] Tested with short prefix session ID — resolves correctly
- [x] Tested `format: "json"` — returns structured data
- [x] Tested `max_messages` — correctly limits output
- [x] Verified tool_use/tool_result content is excluded
- [ ] Upstream CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a transcript tool to retrieve session conversation history.
  * Supports both text and JSON output formats.
  * Configure by session ID (defaults to "latest") and optionally limit messages or request the latest N.
  * Transcripts include session metadata, timestamps, and message attribution.

* **Bug Fixes / Reliability**
  * Improved handling for empty or missing sessions with clearer error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->